### PR TITLE
Fix versions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`5.0.3`, `latest`](https://github.com/herloct/docker-deployer/blob/5.0.3/Dockerfile)
+* [`6.3.0`, `latest`](https://github.com/herloct/docker-deployer/blob/6.3.0/Dockerfile)
+* [`5.0.3`](https://github.com/herloct/docker-deployer/blob/5.0.3/Dockerfile)
 * [`5.0.2`](https://github.com/herloct/docker-deployer/blob/5.0.2/Dockerfile)
 * [`5.0.1`](https://github.com/herloct/docker-deployer/blob/5.0.1/Dockerfile)
 * [`5.0.0`](https://github.com/herloct/docker-deployer/blob/5.0.0/Dockerfile)
 * [`4.3.0`](https://github.com/herloct/docker-deployer/blob/4.3.0/Dockerfile)
 * [`4.2.1`](https://github.com/herloct/docker-deployer/blob/4.2.1/Dockerfile)
+
+> Version 6.3.0 and up are based on PHP 7.2 image
 
 ## What is Deployer?
 


### PR DESCRIPTION
Just fix the missing version 6.3.0 on supported tags section